### PR TITLE
Fix Go modules path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module bearclaw
+module github.com/donuts-are-good/bearclaw
 
 go 1.19
 


### PR DESCRIPTION
This allows `go install github.com/donuts-are-good/bearclaw` to work. Fixes https://github.com/donuts-are-good/bearclaw/issues/5.