### PR TITLE
Fix go.mod for v2 so that go install / go run works

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/donuts-are-good/bearclaw
+module github.com/donuts-are-good/bearclaw/v2
 
 go 1.19
 


### PR DESCRIPTION
### What
Change the module path to include the `/v2` suffix.

### Why
The module has been released for v2.0.0, and when releasing a new major version the module path also needs to be updated to be unique for that major version with the major version as part of the path.

> If the module is released at major version 2 or higher, the module path must end with a [major version suffix](https://go.dev/ref/mod#major-version-suffixes) like /v2.

Ref: https://go.dev/ref/mod#module-path

Without this change installing or running using the go tool will error.

For example:
```console
❯ go run github.com/donuts-are-good/bearclaw@v2.0.0
go: github.com/donuts-are-good/bearclaw@v2.0.0: github.com/donuts-are-good/bearclaw@v2.0.0: invalid version: module contains a go.mod file, so module path must match major version ("github.com/donuts-are-good/bearclaw/v2")
```
```console
❯ go run github.com/donuts-are-good/bearclaw/v2@v2.0.0
go: github.com/donuts-are-good/bearclaw/v2@v2.0.0: github.com/donuts-are-good/bearclaw@v2.0.0: invalid version: module contains a go.mod file, so module path must match major version ("github.com/donuts-are-good/bearclaw/v2")
```
```console
❯ go run github.com/donuts-are-good/bearclaw/v2@latest
go: github.com/donuts-are-good/bearclaw/v2@latest: module github.com/donuts-are-good/bearclaw@latest found (v1.2.1), but does not contain package github.com/donuts-are-good/bearclaw/v2
```